### PR TITLE
Install and run Xapi

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -86,6 +86,9 @@ mount -o bind /dev /mnt/dev
 echo "deb http://ppa.launchpad.net/avsm/ocaml41+opam12/ubuntu trusty main" > /mnt/etc/apt/sources.list.d/ppa-opam.list
 chown root /mnt/etc/apt/sources.list.d/ppa-opam.list
 
+echo "deb http://xenbits.xenproject.org/djs/linaro-xapi-4-4-talex5 ./" > /mnt/etc/apt/sources.list.d/linaro-xapi-4-4-talex5.list
+chown root /mnt/etc/apt/sources.list.d/linaro-xapi-4-4-talex5.list
+
 chroot /mnt apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5B2D0C5561707B09
 
 echo "deb http://ports.ubuntu.com/ubuntu-ports/ trusty-updates main universe 
@@ -99,6 +102,9 @@ chroot /mnt apt-get -y install openssh-server ocaml ocaml-native-compilers camlp
 chroot /mnt apt-get -y install libxml2-dev libdevmapper-dev libpciaccess-dev libnl-dev libgnutls-dev --no-install-recommends
 chroot /mnt apt-get -y install tcpdump telnet nmap tshark tmux locate hping3 traceroute man-db --no-install-recommends
 chroot /mnt apt-get -y install uuid-dev libxen-dev software-properties-common --no-install-recommends
+
+chroot /mnt apt-get -y install xenserver-core thin-provisioning-tools
+
 chroot /mnt apt-get -y clean
 
 rm usr/sbin/policy-rc.d
@@ -112,6 +118,8 @@ echo $BOARD > etc/hostname
 # Mirage user
 chroot /mnt userdel -r linaro
 chroot /mnt useradd -s /bin/bash -G admin -m mirage -p mljnMhCVerQE6	# Password is "mirage"
+mkdir -p /mnt/home/mirage
+cp ${WRKDIR}/templates/dot-xe /mnt/home/mirage/.xe
 sed -i "s/linaro-developer/$BOARD/" etc/hosts
 
 # Xen fixes

--- a/templates/dot-xe
+++ b/templates/dot-xe
@@ -1,0 +1,3 @@
+server=127.0.0.1
+username=mirage
+password=mirage

--- a/templates/init.d/1st-boot
+++ b/templates/init.d/1st-boot
@@ -29,3 +29,49 @@ parted /dev/mmcblk0 --script -- set 3 lvm on
 pvcreate -ffy /dev/mmcblk0p3
 vgcreate vg0 /dev/mmcblk0p3
 vgs
+
+echo Starting Xen
+# Needed for Xenstore and /proc/xen
+/etc/init.d/xen start
+
+echo Configuring xapi
+SERVICES="message-switch forkexecd xcp-networkd xcp-rrdd xenopsd-xenlight xapi-storage-script squeezed xapi"
+for i in $SERVICES; do
+  echo Setting $i to start on default runlevels
+  update-rc.d $i defaults
+  echo Starting $i immediately
+  service $i start
+done
+
+echo Waiting for Xapi to start responding
+RETRIES=60
+while [ ${RETRIES} -ne 0 ]; do
+  ENABLED=$(xe host-list params=enabled --minimal 2>/dev/null)
+  if [ "${ENABLED}" = "true" ]; then
+    echo Xapi startup complete
+    RETRIES=0
+  else
+    sleep 1
+    echo -n .
+    RETRIES=$(( ${RETRIES} - 1 ))
+  fi
+done
+
+echo Creating a thin-LVM SR on flash
+HOST=$(xe host-list params=uuid --minimal)
+# There's a bug causing this to fail
+SR=$(xe sr-create name-label="thin-provisioned LVM" host-uuid=$HOST type=ezlvm device-config:uri=vg:///vg0)
+SR=$(xe sr-list type=ezlvm params=uuid --minimal)
+POOL=$(xe pool-list params=uuid --minimal)
+xe pool-param-set uuid=$POOL default-SR=$SR crash-dump-SR=$SR suspend-image-SR=$SR
+
+echo Setting the network configuration
+HOST=$(xe host-list params=uuid --minimal)
+xe pif-scan host-uuid=$HOST
+PIF=$(xe pif-list device=eth0 params=uuid --minimal)
+xe pif-reconfigure-ip uuid=$PIF mode=dhcp
+xe pif-plug uuid=$PIF
+xe host-management-reconfigure pif-uuid=$PIF
+xe pool-sync-database
+
+echo Setup complete

--- a/templates/interfaces
+++ b/templates/interfaces
@@ -5,6 +5,3 @@ auto eth0
 iface eth0 inet manual
   up ip link set eth0 up
 
-auto br0
-iface br0 inet dhcp
-  bridge_ports eth0

--- a/templates/scripts/make_linux_guest.sh
+++ b/templates/scripts/make_linux_guest.sh
@@ -42,7 +42,7 @@ name = "linux-guest-1"
 vcpus = 2
 serial="pty"
 disk = [ "phy:/dev/vg0/linux-guest-1,xvda,w" ]
-vif = ["bridge=br0"]
+vif = ["bridge=xenbr0"]
 extra = "console=hvc0 xencons=tty root=/dev/xvda"' > linux-guest-1.conf
 
 echo "Done!"


### PR DESCRIPTION
- VMs can be uploaded and run via the XenAPI and `xe`
  - The `mirage`-generated .xe file works
- The host can be managed via XenCenter (and presumably XenOrchestra)
- Historical performance metrics are gathered by `xcp-rrdd`
- VM disks are stored as thinly-provisioned LVM volumes, via `ezlvm`
- The host physical networks are managed by `xcp-networkd`
  - Note the default bridge name is now `xenbr0` rather than `br0`

Note that Xapi runs in parallel with other 'toolstacks' so it is still
possible to use `xl` or `libvirt`.

Signed-off-by: David Scott <dave.scott@citrix.com>