### PR TITLE
Switch from sunxi to upstream U-Boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 linaro-*.tar.gz
 linux-firmware/
 linux/
-u-boot-sunxi/
+u-boot/
 xen/
 boot/
 linux-arm-modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM ubuntu:trusty
-RUN sudo apt-get update
-RUN sudo apt-get install -y build-essential curl
-ADD . /build
-WORKDIR /build
-RUN make clone
-RUN make build

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ ${BOARD}.img: boot/boot-${BOARD}.scr $(ROOTFS)
 
 ## Generate the u-boot boot commands script
 %.scr: %.cmd
-	./u-boot-sunxi/build-${BOARD}/tools/mkimage -C none -A arm -T script -d "$<" "$@"
+	./u-boot/build-${BOARD}/tools/mkimage -C none -A arm -T script -d "$<" "$@"
 
 clean:
 	rm -f cubie*.img boot/boot.*.scr
-	cd u-boot-sunxi && $(MAKE) mrproper
+	cd u-boot && $(MAKE) mrproper

--- a/boot/boot-cubieboard2.cmd
+++ b/boot/boot-cubieboard2.cmd
@@ -1,14 +1,23 @@
-# SUNXI Xen Boot Script
+# Based on the SUNXI Xen Boot Script
 
 # Addresses suitable for 1GB system, adjust as appropriate for a 2GB system.
+
 # Top of RAM:         0x80000000
 # Xen relocate addr   0x7fe00000
-setenv kernel_addr_r  0x7f600000 # 8M
-setenv ramdisk_addr_r 0x7ee00000 # 8M
-setenv fdt_addr       0x7ec00000 # 2M
-setenv xen_addr_r     0x7ea00000 # 2M
 
-setenv fdt_high      0xffffffff # Load fdt in place instead of relocating
+setenv fdt_addr       0x7ec00000 # 2M
+setenv fdt_high       0xffffffff # Load fdt in place instead of relocating
+
+# Put Xen and Linux in the top half of RAM, or you get
+# "Failed to allocate contiguous memory for dom0" (due to the dom0_mem=512M).
+# These used to be at 0x7... but with the latest U-Boot that makes us hang when
+# loading the vmlinuz (use U-Boot's "bdinfo" to see what's in the way).
+setenv kernel_addr_r  0x6ee00000
+setenv xen_addr_r     0x6ea00000 # 2M
+
+# sunxi-common.h contains some more useful information:
+# CONFIG_SYS_TEXT_BASE  0x4a000000 - location of U-Boot's code
+# CONFIG_SYS_SDRAM_BASE 0x40000000 - start of RAM
 
 # Load xen/xen to ${xen_addr_r}.
 fatload mmc 0 ${xen_addr_r} /xen

--- a/boot/boot-cubietruck.cmd
+++ b/boot/boot-cubietruck.cmd
@@ -1,14 +1,23 @@
-# SUNXI Xen Boot Script
+# Based on the SUNXI Xen Boot Script
 
-# Addresses suitable for 1GB system, adjust as appropriate for a 2GB system.
-# Top of RAM:         0x80000000
-# Xen relocate addr   0x7fe00000
-setenv kernel_addr_r  0xbf600000 # 8M
-setenv ramdisk_addr_r 0xbee00000 # 8M
-setenv fdt_addr       0xbec00000 # 2M
-setenv xen_addr_r     0xbea00000 # 2M
+# Addresses suitable for 2GB system
 
-setenv fdt_high      0xffffffff # Load fdt in place instead of relocating
+# Top of RAM:         0xc0000000
+# Xen relocate addr   0xbfe00000
+
+setenv fdt_addr       0xaec00000 # 2M
+setenv fdt_high       0xffffffff # Load fdt in place instead of relocating
+
+# Put Xen and Linux in the top half of RAM, or you get
+# "Failed to allocate contiguous memory for dom0" (due to the dom0_mem=512M).
+# These used to be at 0xb... but with the latest U-Boot that makes us hang when
+# loading the vmlinuz (use U-Boot's "bdinfo" to see what's in the way).
+setenv kernel_addr_r  0xaf600000
+setenv xen_addr_r     0xaea00000 # 2M
+
+# sunxi-common.h contains some more useful information:
+# CONFIG_SYS_TEXT_BASE  0x4a000000 - location of U-Boot's code
+# CONFIG_SYS_SDRAM_BASE 0x40000000 - start of RAM
 
 # Load xen/xen to ${xen_addr_r}.
 fatload mmc 0 ${xen_addr_r} /xen

--- a/build-uboot.sh
+++ b/build-uboot.sh
@@ -6,7 +6,7 @@ cubietruck) TARG=Cubietruck_config ;;
 *) echo Unknown board $BOARD; exit 1;;
 esac
 
-cd u-boot-sunxi
+cd u-boot
 BUILD_DIR=$(pwd)/build-$BOARD
 make O=$BUILD_DIR CROSS_COMPILE=arm-linux-gnueabihf- $TARG
 make O=$BUILD_DIR CROSS_COMPILE=arm-linux-gnueabihf- -j 4

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ losetup -f ${IMG}
 LOOPDEV=$(losetup -j ${IMG} -o 0 | cut -d ":" -f 1)
 
 # Create partition table
-dd if=u-boot-sunxi/build-${BOARD}/u-boot-sunxi-with-spl.bin of=${LOOPDEV} bs=1024 seek=8
+dd if=u-boot/build-${BOARD}/u-boot-sunxi-with-spl.bin of=${LOOPDEV} bs=1024 seek=8
 SIZE=`fdisk -l ${LOOPDEV} | grep Disk | grep bytes | awk '{print $5}'`
 CYLINDERS=`echo $SIZE/255/63/512 | bc`
 WRKDIR=`pwd`

--- a/clone-repos.sh
+++ b/clone-repos.sh
@@ -21,11 +21,11 @@ clone_branch () {
   cd ..
 }
 
-if [ ! -d u-boot-sunxi ]; then
-  clone_branch git://github.com/jwrdegoede u-boot-sunxi sunxi-next
+if [ ! -d u-boot ]; then
+  git clone git://git.denx.de/u-boot.git -b v2015.04
 else
-  cd u-boot-sunxi
-  git pull --ff-only origin sunxi-next
+  cd u-boot
+  git pull --ff-only origin v2015.04
   cd ..
 fi
 
@@ -57,11 +57,11 @@ fi
 
 if [ ! -d xen ]; then
   #clone_branch git://xenbits.xen.org xen stable-4.4
-  clone_branch https://github.com/talex5 xen stable-4.4
+  clone_branch https://github.com/talex5 xen fix-grant-mapping
 else
   cd xen
   #git pull origin stable-4.4
-  git pull --ff-only https://github.com/talex5/xen.git stable-4.4
+  git pull --ff-only https://github.com/talex5/xen.git fix-grant-mapping
   cd ..
 fi
 

--- a/mkdocker/Dockerfile
+++ b/mkdocker/Dockerfile
@@ -1,0 +1,11 @@
+# If you're not on Debian/Ubuntu, you can use this to make a suitable Docker image.
+# You'll need to run it with --privileged however.
+# To build: docker build -t xen-sdcard-builder .
+FROM ubuntu:trusty
+RUN sudo apt-get update
+RUN sudo apt-get install -y curl gcc-arm-linux-gnueabihf rsync git build-essential qemu kpartx binfmt-support qemu-user-static python bc parted dosfstools
+RUN sudo mknod /dev/loop0 -m0660 b 7 0
+#ADD . /build
+#WORKDIR /build
+#RUN make clone
+#RUN make build


### PR DESCRIPTION
The patches we need were merged long ago.

Also, fix the Xen branch we use (was lost when the repository became a fork of mirage/xen).

The new U-Boot has a different memory layout and so requires Xen and Linux to be loaded at a different address. Thanks to @infidel for finding out what had moved there and to @Furao  for updating for the CubieTruck.

Fixes #57.