### PR TITLE
do not preserve owner in tar if running as root

### DIFF
--- a/image.sh
+++ b/image.sh
@@ -44,7 +44,7 @@ losetup -D && LOFS=$(losetup -f --show -o$((2048*512)) sdcard.img)
 mkfs.vfat $LOFS
 
 mount $LOFS /mnt
-tar -C /mnt -xaf src/$ALPINETGZ
+tar --no-same-owner -C /mnt -xaf src/$ALPINETGZ
 
 cp $ZIMAGE /mnt/boot/vmlinuz
 cp $DTB /mnt/boot


### PR DESCRIPTION
gnu tar has a strange idea to set the owner sometimes. it would like to use the docker containers uid (1000) on vfat, can't and aborts the time building. result is that spl is missing and card is unbootable.
this option disables that feature.